### PR TITLE
Retry with alternative streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Dieses CLI-Tool lädt Videos mit [yt-dlp](https://github.com/yt-dlp/yt-dlp) heru
 2. Abhängigkeiten installieren:
    ```bash
    pip install -r requirements.txt
+   ```
+
+Beim Download zeigt das Tool gefundene Stream-URLs an und sortiert sie nach Größe.
+Sollte die erste URL von `yt-dlp` nicht unterstützt werden, versucht das Programm
+automatisch die nächsten Kandidaten, bis ein Download gelingt.

--- a/downloader.py
+++ b/downloader.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import requests
 from yt_dlp import YoutubeDL
+from yt_dlp.utils import DownloadError
 from playwright.async_api import async_playwright
 from rich.table import Table
 
@@ -161,9 +162,9 @@ def _head_size(url: str) -> Optional[int]:
         return None
 
 
-def resolve_url(url: str, ui) -> str:
+def resolve_url(url: str, ui) -> list[str]:
     if url.split("?")[0].endswith(STREAM_EXTS):
-        return url
+        return [url]
 
     embeds: list[str] = []
     try:
@@ -182,7 +183,7 @@ def resolve_url(url: str, ui) -> str:
 
     candidates = list(dict.fromkeys(embeds + sniffed))
     if not candidates:
-        return url
+        return [url]
 
     with ThreadPoolExecutor() as ex:
         sizes = list(ex.map(_head_size, candidates))
@@ -203,7 +204,12 @@ def resolve_url(url: str, ui) -> str:
     except ValueError:
         idx = 0
     idx = max(0, min(idx, len(items) - 1))
-    return items[idx][0]
+
+    # return selected URL first, followed by the remaining candidates so callers
+    # can try alternatives if the first choice fails
+    ordered = [items[idx][0]]
+    ordered.extend(s for i, (s, _) in enumerate(items) if i != idx)
+    return ordered
 
 
 def download(url: str, out: str, ui) -> str:
@@ -261,9 +267,14 @@ def disconnect_vpn(ui) -> None:
     ui.log("Trenne VPN")
     subprocess.run(["surfshark-vpn", "disconnect"], check=False)
 
-
 def process(url: str, cfg, ui) -> None:
-    target = resolve_url(url, ui)
-    path = download(target, cfg.out, ui)
-    if path:
-        upload_to_koofr(path, cfg, ui)
+    candidates = resolve_url(url, ui)
+    for target in candidates:
+        try:
+            path = download(target, cfg.out, ui)
+        except DownloadError:
+            ui.log(f"yt-dlp konnte {target} nicht verarbeiten, versuche nächste URL")
+            continue
+        if path:
+            upload_to_koofr(path, cfg, ui)
+        break


### PR DESCRIPTION
## Summary
- try remaining stream candidates when yt-dlp reports an unsupported URL
- document automatic fallback behaviour in README

## Testing
- `python -m py_compile downloader.py main.py ui.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68a83b40beb883219d0f52d91e5cb65a