### PR TITLE
Retry with alternative streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Sollte die erste URL von `yt-dlp` nicht unterstützt werden, versucht das Progra
 automatisch die nächsten Kandidaten, bis ein Download gelingt.
 Falls alle Kandidaten fehlschlagen, wird jede URL mit Playwright erneut erkundet,
 um darin versteckte `.m3u8`/`.mpd`/`.mp4`-Streams zu finden.
+Alle Meldungen von `yt-dlp` werden zusätzlich in `downloader.log`
+gespeichert, um die Fehlersuche zu erleichtern.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ Dieses CLI-Tool lädt Videos mit [yt-dlp](https://github.com/yt-dlp/yt-dlp) heru
 2. Abhängigkeiten installieren:
    ```bash
    pip install -r requirements.txt
+   ```
+
+Beim Download zeigt das Tool gefundene Stream-URLs an und sortiert sie nach Größe.
+Sollte die erste URL von `yt-dlp` nicht unterstützt werden, versucht das Programm
+automatisch die nächsten Kandidaten, bis ein Download gelingt.
+Falls alle Kandidaten fehlschlagen, wird jede URL mit Playwright erneut erkundet,
+um darin versteckte `.m3u8`/`.mpd`/`.mp4`-Streams zu finden.

--- a/downloader.py
+++ b/downloader.py
@@ -227,6 +227,21 @@ def download(url: str, out: str, ui) -> str:
             result["path"] = d.get("filename")
             ui.log(f"Finished {d.get('filename')}")
 
+    class YTLogger:
+        def __init__(self, ui):
+            self.ui = ui
+
+        def debug(self, msg):
+            self.ui.log(msg)
+
+        info = debug
+
+        def warning(self, msg):
+            self.ui.log(f"[yellow]{msg}[/yellow]")
+
+        def error(self, msg):
+            self.ui.log(f"[red]{msg}[/red]")
+
     ydl_opts = {
         "outtmpl": str(Path(out) / "%(title)s.%(ext)s"),
         "progress_hooks": [hook],
@@ -235,7 +250,9 @@ def download(url: str, out: str, ui) -> str:
         "extractor_args": {"generic": ["impersonate"]},
         # disable yt-dlp's own progress output so only the rich progress bar is shown
         "noprogress": True,
-        "quiet": True,
+        "quiet": False,
+        "verbose": True,
+        "logger": YTLogger(ui),
     }
     with YoutubeDL(ydl_opts) as ydl:
         ydl.download([url])
@@ -276,14 +293,15 @@ def process(url: str, cfg, ui) -> None:
         if target in seen:
             continue
         seen.add(target)
+        ui.log(f"Versuche {target}")
         try:
             path = download(target, cfg.out, ui)
-        except DownloadError:
-            ui.log(f"yt-dlp konnte {target} nicht verarbeiten, versuche nächste URL")
+        except Exception as e:
+            ui.log(f"yt-dlp konnte {target} nicht verarbeiten: {e}; versuche nächste URL")
             try:
                 extra = asyncio.run(_sniff(target, ui))
-            except Exception as e:
-                ui.log(f"Sniff fehlgeschlagen: {e}")
+            except Exception as e2:
+                ui.log(f"Sniff fehlgeschlagen: {e2}")
             else:
                 candidates.extend(extra)
             continue


### PR DESCRIPTION
## Summary
- try remaining stream candidates when yt-dlp reports an unsupported URL
- document automatic fallback behaviour in README
- sniff failed stream pages with Playwright to discover direct media links

## Testing
- `python -m py_compile downloader.py main.py ui.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68a83b40beb883219d0f52d91e5cb65a