### PR TITLE
feat: enable sniffing in simple GUI

### DIFF
--- a/simple_gui.py
+++ b/simple_gui.py
@@ -1,10 +1,10 @@
 import tkinter as tk
+from tkinter import ttk
 from tkinter.scrolledtext import ScrolledText
 from threading import Thread
 from queue import Queue
-from pathlib import Path
-import os
-from yt_dlp import YoutubeDL
+from types import SimpleNamespace
+from downloader import process
 
 
 def append_log(msg: str) -> None:
@@ -12,70 +12,124 @@ def append_log(msg: str) -> None:
     log_queue.put(msg)
 
 
-def download_url(url: str, log) -> None:
-    """Download ``url`` using yt-dlp, logging progress via ``log``."""
-    base = url.rstrip('/').split('/')[-1].split('?')[0]
-    name = os.path.splitext(base)[0]
-    outdir = Path("downloads")
-    outdir.mkdir(exist_ok=True)
-    outtmpl = str(outdir / f"{name}.%(ext)s")
+def queue_progress(name: str, percent: float, speed: str, eta: str) -> None:
+    """Forward progress updates to the main thread."""
+    progress_queue.put((name, percent, speed, eta))
 
-    def hook(d):
-        if d.get("status") == "downloading":
-            total = d.get("total_bytes") or d.get("total_bytes_estimate") or 1
-            percent = d.get("downloaded_bytes", 0) / total * 100
-            speed = d.get("_speed_str", "")
-            eta = d.get("_eta_str", "")
-            log(f"{percent:5.1f}% {speed} ETA {eta}")
-        elif d.get("status") == "finished":
-            log(f"Abgeschlossen: {d.get('filename')}")
 
-    ydl_opts = {
-        "outtmpl": outtmpl,
-        "progress_hooks": [hook],
-        "noprogress": True,
-        "quiet": True,
-    }
-    with YoutubeDL(ydl_opts) as ydl:
-        ydl.download([url])
+class TkConsole:
+    def print(self, *args, **kwargs):
+        append_log(" ".join(str(a) for a in args))
+
+    def input(self, prompt: str = "") -> str:
+        append_log(prompt)
+        return ""  # use default selection
+
+
+class TkUI:
+    def __init__(self):
+        self.console = TkConsole()
+
+    def log(self, msg: str) -> None:
+        append_log(str(msg))
+
+    def update_progress(self, name: str, percent: float, speed: str = "", eta: str = "") -> None:
+        queue_progress(name, percent, speed, eta)
 
 
 def worker(url: str) -> None:
     append_log(f"Starte Download: {url}")
+    ui = TkUI()
+    cfg = SimpleNamespace(
+        out="downloads",
+        koofr_user=None,
+        koofr_password=None,
+        koofr_base="",
+        surfshark_server=None,
+    )
     try:
-        download_url(url, append_log)
+        process(url, cfg, ui)
         append_log("Fertig.")
     except Exception as e:
         append_log(f"Fehler: {e}")
+    finally:
+        done_queue.put(True)
 
 
 def start_download() -> None:
     url = entry.get().strip()
     if not url:
         return
+    entry.config(state=tk.DISABLED)
+    btn.config(state=tk.DISABLED)
+    progress_var.set(0)
+    pb.config(mode="indeterminate")
+    pb.start(10)
+    status_var.set("Verbinde…")
     Thread(target=worker, args=(url,), daemon=True).start()
 
 
-def update_log() -> None:
+def poll_queues() -> None:
     while not log_queue.empty():
         text.insert(tk.END, log_queue.get() + "\n")
         text.see(tk.END)
-    root.after(100, update_log)
+
+    while not progress_queue.empty():
+        name, percent, speed, eta = progress_queue.get()
+        if str(pb.cget("mode")) == "indeterminate":
+            pb.stop()
+            pb.config(mode="determinate")
+        progress_var.set(percent)
+        status_var.set(f"{name}: {percent:5.1f}% {speed} ETA {eta}")
+
+    while not done_queue.empty():
+        done_queue.get()
+        pb.stop()
+        pb.config(mode="determinate")
+        progress_var.set(0)
+        status_var.set("Bereit")
+        entry.config(state=tk.NORMAL)
+        btn.config(state=tk.NORMAL)
+
+    root.after(100, poll_queues)
 
 
 root = tk.Tk()
 root.title("Downloader")
 
-entry = tk.Entry(root, width=50)
-entry.pack(padx=5, pady=5)
+style = ttk.Style(root)
+try:
+    style.theme_use("clam")
+except tk.TclError:
+    pass
+style.configure("TProgressbar", thickness=12)
+style.configure("TButton", padding=6)
 
-btn = tk.Button(root, text="Download", command=start_download)
-btn.pack(padx=5, pady=5)
+frame = ttk.Frame(root, padding=10)
+frame.pack(fill="both", expand=True)
+frame.columnconfigure(0, weight=1)
 
-text = ScrolledText(root, width=60, height=20)
-text.pack(padx=5, pady=5)
+entry = ttk.Entry(frame, width=50)
+entry.grid(row=0, column=0, padx=5, pady=5, sticky="ew")
 
-log_queue = Queue()
-update_log()
+btn = ttk.Button(frame, text="Download", command=start_download)
+btn.grid(row=0, column=1, padx=5, pady=5)
+
+progress_var = tk.DoubleVar(value=0)
+pb = ttk.Progressbar(frame, variable=progress_var, maximum=100)
+pb.grid(row=1, column=0, columnspan=2, sticky="ew", padx=5, pady=5)
+
+status_var = tk.StringVar(value="Bereit")
+status = ttk.Label(frame, textvariable=status_var)
+status.grid(row=2, column=0, columnspan=2, sticky="w", padx=5)
+
+text = ScrolledText(frame, width=60, height=15)
+text.grid(row=3, column=0, columnspan=2, sticky="nsew", padx=5, pady=5)
+frame.rowconfigure(3, weight=1)
+
+log_queue: Queue[str] = Queue()
+progress_queue: Queue[tuple[str, float, str, str]] = Queue()
+done_queue: Queue[bool] = Queue()
+poll_queues()
 
 root.mainloop()


### PR DESCRIPTION
## Summary
- extend `simple_gui.py` to reuse downloader logic with sniffing
- add Tk UI adapter for logging and progress
- skip Playwright sniffing when browsers are missing and log a helpful hint
- restyle GUI with ttk themed widgets and animated progress bar

## Testing
- `python -m pytest`
- `python -m py_compile simple_gui.py downloader.py`


------
https://chatgpt.com/codex/tasks/task_e_68b86524449c8321bceba4d506ef3bd5