### PR TITLE
feat: enable sniffing in simple GUI

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -3,12 +3,16 @@ import re
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import requests
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 from playwright.async_api import async_playwright
+
+# flag to avoid repeatedly trying Playwright when the bundled browsers are
+# missing and sniffing is therefore impossible
+PLAYWRIGHT_AVAILABLE = True
 from rich.table import Table
 
 STREAM_EXTS = (".m3u8", ".mpd", ".mp4")
@@ -57,85 +61,93 @@ def _extract_embeds(html: str) -> list[str]:
 async def _sniff(url: str, ui=None) -> list[str]:
     """Capture media requests by exploring the page with Playwright.
 
-    The function is declared as a coroutine so that ``await`` statements such
-    as ``page.goto`` operate within an async context, preventing the
-    "await outside async function" syntax error reported by some users.
+    If launching the browser fails (e.g. because ``playwright install`` wasn't
+    run), the failure is propagated and ``PLAYWRIGHT_AVAILABLE`` is set to
+    ``False`` so later calls can skip sniffing altogether.
     """
-    async with async_playwright() as pw:
-        browser = await pw.firefox.launch(headless=True)
-        context = await browser.new_context()
+    global PLAYWRIGHT_AVAILABLE
+    try:
+        async with async_playwright() as pw:
+            browser = await pw.firefox.launch(headless=True)
+            context = await browser.new_context()
 
-        async def block_ads(route):
-            if any(pat in route.request.url for pat in AD_PATTERNS):
-                if ui:
-                    ui.log(f"Blocked {route.request.url}")
-                await route.abort()
-            else:
-                await route.continue_()
+            async def block_ads(route):
+                if any(pat in route.request.url for pat in AD_PATTERNS):
+                    if ui:
+                        ui.log(f"Blocked {route.request.url}")
+                    await route.abort()
+                else:
+                    await route.continue_()
 
-        await context.route("**", block_ads)
+            await context.route("**", block_ads)
 
-        page = await context.new_page()
-        page.on("popup", lambda p: asyncio.create_task(p.close()))
-        context.on("page", lambda p: asyncio.create_task(p.close()))
+            page = await context.new_page()
+            page.on("popup", lambda p: asyncio.create_task(p.close()))
+            context.on("page", lambda p: asyncio.create_task(p.close()))
 
-        found: set[str] = set()
+            found: set[str] = set()
 
-        async def handle_response(response):
-            u = response.url.split("?")[0]
-            if u.endswith(STREAM_EXTS):
-                found.add(response.url)
-                if ui:
-                    ui.log(f"Found {response.url}")
+            async def handle_response(response):
+                u = response.url.split("?")[0]
+                if u.endswith(STREAM_EXTS):
+                    found.add(response.url)
+                    if ui:
+                        ui.log(f"Found {response.url}")
 
-        context.on("response", handle_response)
+            context.on("response", handle_response)
 
-        # Visiting some pages takes a while. We do not want navigation
-        # timeouts to abort sniffing, so swallow any errors and keep waiting
-        # for network responses instead.
-        try:
-            await page.goto(url, timeout=60_000)
-        except Exception:
-            pass
-
-        visited: set[int] = set()
-
-        async def trigger(frame):
-            fid = id(frame)
-            if fid in visited:
-                return
-            visited.add(fid)
-
-            selectors = [
-                "button[aria-label*=play i]",
-                "button",
-                "div[role=button]",
-                "div[id*=play]",
-                "div[class*=play]",
-                "span[class*=play]",
-                "video",
-            ]
-            for sel in selectors:
-                try:
-                    await frame.locator(sel).first.click(timeout=1_000, force=True, no_wait_after=True)
-                    break
-                except Exception:
-                    continue
+            # Visiting some pages takes a while. We do not want navigation
+            # timeouts to abort sniffing, so swallow any errors and keep waiting
+            # for network responses instead.
             try:
-                await frame.evaluate("document.querySelectorAll('video').forEach(v=>v.play())")
+                await page.goto(url, timeout=60_000)
             except Exception:
                 pass
 
-        page.on("frameattached", lambda f: asyncio.create_task(trigger(f)))
+            visited: set[int] = set()
 
-        end = asyncio.get_event_loop().time() + 30
-        while asyncio.get_event_loop().time() < end:
-            for f in page.frames:
-                await trigger(f)
-            await asyncio.sleep(2)
+            async def trigger(frame):
+                fid = id(frame)
+                if fid in visited:
+                    return
+                visited.add(fid)
 
-        await browser.close()
-        return list(found)
+                selectors = [
+                    "button[aria-label*=play i]",
+                    "button",
+                    "div[role=button]",
+                    "div[id*=play]",
+                    "div[class*=play]",
+                    "span[class*=play]",
+                    "video",
+                ]
+                for sel in selectors:
+                    try:
+                        await frame.locator(sel).first.click(timeout=1_000, force=True, no_wait_after=True)
+                        break
+                    except Exception:
+                        continue
+                try:
+                    await frame.evaluate("document.querySelectorAll('video').forEach(v=>v.play())")
+                except Exception:
+                    pass
+
+            page.on("frameattached", lambda f: asyncio.create_task(trigger(f)))
+
+            end = asyncio.get_event_loop().time() + 30
+            while asyncio.get_event_loop().time() < end:
+                for f in page.frames:
+                    await trigger(f)
+                await asyncio.sleep(2)
+
+            await browser.close()
+            return list(found)
+    except Exception as e:
+        PLAYWRIGHT_AVAILABLE = False
+        if "Executable doesn't exist" in str(e) and ui:
+            # Offer a concise hint for the common case of missing browsers
+            ui.log("Playwright-Browser fehlen – `playwright install` ausführen")
+        raise
 
 
 def _format_size(size: Optional[int]) -> str:
@@ -148,22 +160,55 @@ def _format_size(size: Optional[int]) -> str:
     return f"{size:.1f} TB"
 
 
-def _head_size(url: str) -> Optional[int]:
+def _probe_stream(url: str) -> Tuple[int, Optional[int], Optional[str]]:
+    """Return ``(height, size, error)`` for ``url``.
+
+    ``error`` contains a short message if probing failed.
+    """
     try:
-        resp = requests.head(
-            url,
-            allow_redirects=True,
-            timeout=10,
-            headers={"User-Agent": "Mozilla/5.0"},
-        )
-        cl = resp.headers.get("Content-Length")
-        return int(cl) if cl else None
+        with YoutubeDL({"quiet": True}) as ydl:
+            info = ydl.extract_info(url, download=False)
+        formats = info.get("formats") or [info]
+        best = max(formats, key=lambda f: f.get("height") or 0)
+        height = best.get("height") or 0
+        size = best.get("filesize") or best.get("filesize_approx")
+        return height, size, None
+    except Exception as e:
+        return 0, None, str(e)
+
+
+def _verify_resolution(path: str) -> int:
+    """Return the height of the first video stream in ``path``.
+
+    This uses ``ffprobe`` on the downloaded file as a fallback verification
+    step since some hosts may not expose accurate metadata via yt-dlp.
+    """
+    try:
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=height",
+            "-of",
+            "csv=p=0",
+            path,
+        ]
+        out = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return int(out.stdout.strip())
     except Exception:
-        return None
+        return 0
 
 
 def resolve_url(url: str, ui) -> list[str]:
     if url.split("?")[0].endswith(STREAM_EXTS):
+        height, _, err = _probe_stream(url)
+        if err:
+            raise RuntimeError(f"Stream nicht nutzbar: {err}")
+        if height < 1080:
+            raise RuntimeError("Kein Full-HD Stream gefunden")
         return [url]
 
     embeds: list[str] = []
@@ -173,42 +218,73 @@ def resolve_url(url: str, ui) -> list[str]:
     except Exception:
         pass
 
-    sniffed: list[str] = []
-    if not embeds:
-        ui.log("Sniffing stream URL via Playwright")
+    candidates = list(dict.fromkeys(embeds))
+
+    def probe(cands: list[str]):
+        if not cands:
+            return []
+        with ThreadPoolExecutor() as ex:
+            infos = list(ex.map(_probe_stream, cands))
+        items = list(zip(cands, infos))
+        return sorted(
+            items,
+            key=lambda x: ((x[1][0] or 0), x[1][1] or 0),
+            reverse=True,
+        )
+
+    items = probe(candidates)
+
+    for s, (h, _, err) in items:
+        if err:
+            ui.log(f"{s} nicht nutzbar: {err}")
+        elif h < 1080:
+            ui.log(f"{s} bietet nur {h}p")
+
+    hd_items = [(s, info) for s, info in items if info[0] >= 1080 and not info[2]]
+
+    if not hd_items and PLAYWRIGHT_AVAILABLE:
+        ui.log("Keine Full-HD Streams gefunden – starte Playwright-Sniffing")
+        sniffed: list[str] = []
         try:
             sniffed = asyncio.run(_sniff(url, ui))
         except Exception as e:
             ui.log(f"Sniff failed: {e}")
+        candidates = list(dict.fromkeys(candidates + sniffed))
+        items = probe(candidates)
+        for s, (h, _, err) in items:
+            if err:
+                ui.log(f"{s} nicht nutzbar: {err}")
+            elif h < 1080:
+                ui.log(f"{s} bietet nur {h}p")
+        hd_items = [(s, info) for s, info in items if info[0] >= 1080 and not info[2]]
 
-    candidates = list(dict.fromkeys(embeds + sniffed))
-    if not candidates:
-        return [url]
-
-    with ThreadPoolExecutor() as ex:
-        sizes = list(ex.map(_head_size, candidates))
-    items = sorted(zip(candidates, sizes), key=lambda x: x[1] or 0, reverse=True)
+    if not items:
+        raise RuntimeError("Kein Full-HD Stream gefunden")
 
     table = Table(title="Gefundene Streams")
     table.add_column("Nr")
     table.add_column("URL")
+    table.add_column("Qualität")
     table.add_column("Größe")
-    for i, (s, size) in enumerate(items, start=1):
-        table.add_row(str(i), s, _format_size(size))
+    for i, (s, (h, size, err)) in enumerate(items, start=1):
+        qual = f"{h}p" if h else "?"
+        if err:
+            qual = "-"
+        table.add_row(str(i), s, qual, _format_size(size))
     ui.console.print(table)
 
-    # use Rich's input method so the prompt remains visible while the progress bar is active
+    if not hd_items:
+        raise RuntimeError("Kein Full-HD Stream gefunden")
+
     choice = ui.console.input("Welche URL verwenden? [1]: ")
     try:
         idx = int(choice) - 1 if choice.strip() else 0
     except ValueError:
         idx = 0
-    idx = max(0, min(idx, len(items) - 1))
+    idx = max(0, min(idx, len(hd_items) - 1))
 
-    # return selected URL first, followed by the remaining candidates so callers
-    # can try alternatives if the first choice fails
-    ordered = [items[idx][0]]
-    ordered.extend(s for i, (s, _) in enumerate(items) if i != idx)
+    ordered = [hd_items[idx][0]]
+    ordered.extend(s for i, (s, _) in enumerate(hd_items) if i != idx)
     return ordered
 
 
@@ -248,6 +324,8 @@ def download(url: str, out: str, ui) -> str:
         "concurrent_fragment_downloads": 5,
         # Use HTTP client impersonation to bypass Cloudflare checks on generic sites
         "extractor_args": {"generic": ["impersonate"]},
+        # ensure at least Full HD quality
+        "format": "bestvideo[height>=1080]+bestaudio/best[height>=1080]",
         # disable yt-dlp's own progress output so only the rich progress bar is shown
         "noprogress": True,
         "quiet": False,
@@ -295,20 +373,42 @@ def process(url: str, cfg, ui) -> None:
             continue
         seen.add(target)
         ui.log(f"Versuche {target}")
+        height, _, err = _probe_stream(target)
+        if err:
+            ui.log(f"Stream {target} nicht nutzbar: {err}")
+            continue
+        if height < 1080:
+            ui.log(f"Stream {target} bietet nur {height}p – überspringe")
+            continue
         try:
             path = download(target, cfg.out, ui)
         except Exception as e:
             ui.log(f"yt-dlp konnte {target} nicht verarbeiten: {e}; versuche nächste URL")
-            try:
-                extra = asyncio.run(_sniff(target, ui))
-            except Exception as e2:
-                ui.log(f"Sniff fehlgeschlagen: {e2}")
-            else:
-                # Try freshly sniffed stream URLs before any remaining
-                # unresolved candidates so that direct media links are
-                # attempted immediately on the next loop iteration.
-                candidates[0:0] = extra
+            if PLAYWRIGHT_AVAILABLE:
+                try:
+                    extra = asyncio.run(_sniff(target, ui))
+                except Exception as e2:
+                    ui.log(f"Sniff fehlgeschlagen: {e2}")
+                else:
+                    hd_extra = []
+                    for s in extra:
+                        h, _, err = _probe_stream(s)
+                        if err:
+                            ui.log(f"{s} nicht nutzbar: {err}")
+                        elif h < 1080:
+                            ui.log(f"{s} bietet nur {h}p")
+                        else:
+                            hd_extra.append(s)
+                    candidates[0:0] = hd_extra
             continue
         if path:
+            final_height = _verify_resolution(path)
+            if final_height < 1080:
+                ui.log(f"Download bietet nur {final_height}p – versuche nächste URL")
+                try:
+                    Path(path).unlink()
+                except Exception:
+                    pass
+                continue
             upload_to_koofr(path, cfg, ui)
             break

--- a/simple_gui.py
+++ b/simple_gui.py
@@ -1,10 +1,10 @@
 import tkinter as tk
+from tkinter import ttk
 from tkinter.scrolledtext import ScrolledText
 from threading import Thread
 from queue import Queue
-from pathlib import Path
-import os
-from yt_dlp import YoutubeDL
+from types import SimpleNamespace
+from downloader import process
 
 
 def append_log(msg: str) -> None:
@@ -12,70 +12,124 @@ def append_log(msg: str) -> None:
     log_queue.put(msg)
 
 
-def download_url(url: str, log) -> None:
-    """Download ``url`` using yt-dlp, logging progress via ``log``."""
-    base = url.rstrip('/').split('/')[-1].split('?')[0]
-    name = os.path.splitext(base)[0]
-    outdir = Path("downloads")
-    outdir.mkdir(exist_ok=True)
-    outtmpl = str(outdir / f"{name}.%(ext)s")
+def queue_progress(name: str, percent: float, speed: str, eta: str) -> None:
+    """Forward progress updates to the main thread."""
+    progress_queue.put((name, percent, speed, eta))
 
-    def hook(d):
-        if d.get("status") == "downloading":
-            total = d.get("total_bytes") or d.get("total_bytes_estimate") or 1
-            percent = d.get("downloaded_bytes", 0) / total * 100
-            speed = d.get("_speed_str", "")
-            eta = d.get("_eta_str", "")
-            log(f"{percent:5.1f}% {speed} ETA {eta}")
-        elif d.get("status") == "finished":
-            log(f"Abgeschlossen: {d.get('filename')}")
 
-    ydl_opts = {
-        "outtmpl": outtmpl,
-        "progress_hooks": [hook],
-        "noprogress": True,
-        "quiet": True,
-    }
-    with YoutubeDL(ydl_opts) as ydl:
-        ydl.download([url])
+class TkConsole:
+    def print(self, *args, **kwargs):
+        append_log(" ".join(str(a) for a in args))
+
+    def input(self, prompt: str = "") -> str:
+        append_log(prompt)
+        return ""  # use default selection
+
+
+class TkUI:
+    def __init__(self):
+        self.console = TkConsole()
+
+    def log(self, msg: str) -> None:
+        append_log(str(msg))
+
+    def update_progress(self, name: str, percent: float, speed: str = "", eta: str = "") -> None:
+        queue_progress(name, percent, speed, eta)
 
 
 def worker(url: str) -> None:
     append_log(f"Starte Download: {url}")
+    ui = TkUI()
+    cfg = SimpleNamespace(
+        out="downloads",
+        koofr_user=None,
+        koofr_password=None,
+        koofr_base="",
+        surfshark_server=None,
+    )
     try:
-        download_url(url, append_log)
+        process(url, cfg, ui)
         append_log("Fertig.")
     except Exception as e:
         append_log(f"Fehler: {e}")
+    finally:
+        done_queue.put(True)
 
 
 def start_download() -> None:
     url = entry.get().strip()
     if not url:
         return
+    entry.config(state=tk.DISABLED)
+    btn.config(state=tk.DISABLED)
+    progress_var.set(0)
+    pb.config(mode="indeterminate")
+    pb.start(10)
+    status_var.set("Verbinde…")
     Thread(target=worker, args=(url,), daemon=True).start()
 
 
-def update_log() -> None:
+def poll_queues() -> None:
     while not log_queue.empty():
         text.insert(tk.END, log_queue.get() + "\n")
         text.see(tk.END)
-    root.after(100, update_log)
+
+    while not progress_queue.empty():
+        name, percent, speed, eta = progress_queue.get()
+        if str(pb.cget("mode")) == "indeterminate":
+            pb.stop()
+            pb.config(mode="determinate")
+        progress_var.set(percent)
+        status_var.set(f"{name}: {percent:5.1f}% {speed} ETA {eta}")
+
+    while not done_queue.empty():
+        done_queue.get()
+        pb.stop()
+        pb.config(mode="determinate")
+        progress_var.set(0)
+        status_var.set("Bereit")
+        entry.config(state=tk.NORMAL)
+        btn.config(state=tk.NORMAL)
+
+    root.after(100, poll_queues)
 
 
 root = tk.Tk()
 root.title("Downloader")
 
-entry = tk.Entry(root, width=50)
-entry.pack(padx=5, pady=5)
+style = ttk.Style(root)
+try:
+    style.theme_use("clam")
+except tk.TclError:
+    pass
+style.configure("TProgressbar", thickness=12)
+style.configure("TButton", padding=6)
 
-btn = tk.Button(root, text="Download", command=start_download)
-btn.pack(padx=5, pady=5)
+frame = ttk.Frame(root, padding=10)
+frame.pack(fill="both", expand=True)
+frame.columnconfigure(0, weight=1)
 
-text = ScrolledText(root, width=60, height=20)
-text.pack(padx=5, pady=5)
+entry = ttk.Entry(frame, width=50)
+entry.grid(row=0, column=0, padx=5, pady=5, sticky="ew")
 
-log_queue = Queue()
-update_log()
+btn = ttk.Button(frame, text="Download", command=start_download)
+btn.grid(row=0, column=1, padx=5, pady=5)
+
+progress_var = tk.DoubleVar(value=0)
+pb = ttk.Progressbar(frame, variable=progress_var, maximum=100)
+pb.grid(row=1, column=0, columnspan=2, sticky="ew", padx=5, pady=5)
+
+status_var = tk.StringVar(value="Bereit")
+status = ttk.Label(frame, textvariable=status_var)
+status.grid(row=2, column=0, columnspan=2, sticky="w", padx=5)
+
+text = ScrolledText(frame, width=60, height=15)
+text.grid(row=3, column=0, columnspan=2, sticky="nsew", padx=5, pady=5)
+frame.rowconfigure(3, weight=1)
+
+log_queue: Queue[str] = Queue()
+progress_queue: Queue[tuple[str, float, str, str]] = Queue()
+done_queue: Queue[bool] = Queue()
+poll_queues()
 
 root.mainloop()


### PR DESCRIPTION
## Summary
- extend `simple_gui.py` to reuse downloader logic with sniffing
- add Tk UI adapter for logging and progress
- skip Playwright sniffing when browsers are missing and log a helpful hint
- restyle GUI with ttk themed widgets and animated progress bar
- probe stream formats to ensure at least Full HD quality before downloading
- fall back to Playwright sniffing when no Full-HD streams are found from page embeds
- verify downloaded files with ffprobe and retry if resolution below 1080p
- precheck every stream link and report why unusable candidates fail

## Testing
- `python -m py_compile simple_gui.py downloader.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b86524449c8321bceba4d506ef3bd5