### PR TITLE
feat: fallback to lower stream quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ der ein Stream akzeptiert wird. Standardmäßig steht der Wert auf 1080:
 min_height: 1080
 ```
 
+Ist in dieser Auflösung kein Stream verfügbar, fällt das Programm automatisch
+auf die jeweils nächst niedrigere Qualität zurück.
+
 Beim Download zeigt das Tool gefundene Stream-URLs an und sortiert sie nach Größe.
 Sollte die erste URL von `yt-dlp` nicht unterstützt werden, versucht das Programm
 automatisch die nächsten Kandidaten, bis ein Download gelingt.


### PR DESCRIPTION
## Summary
- allow resolve_url to fall back to next lower quality when desired resolution missing
- propagate chosen resolution through download process
- document automatic quality fallback in README

## Testing
- `python -m py_compile downloader.py main.py simple_gui.py ui.py config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b88011575c83219f9b2008d94a9283