### PR TITLE
feat(setup): create desktop launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,41 @@ Dieses CLI-Tool lädt Videos mit [yt-dlp](https://github.com/yt-dlp/yt-dlp) heru
 
 ## Setup
 
+### Schnellstart
+
+```bash
+python setup.py
+```
+
+Der Befehl legt eine virtuelle Umgebung in `.venv` an, installiert alle
+Abhängigkeiten (inklusive der Bibliotheken für Cloudflare-Impersonation
+und Playwrights Firefox) und erzeugt ein Startskript (`run_gui.bat` bzw.
+`run_gui.sh`) im Projektordner. Ist ein Desktop-Verzeichnis vorhanden,
+wird die Datei zusätzlich dorthin kopiert, sodass die GUI direkt per
+Doppelklick gestartet werden kann. Unter Windows nutzt der Launcher
+`pythonw.exe`, damit kein Konsolenfenster geöffnet bleibt.
+
+### Manuell
+
 1. Python 3.11+ installieren
 2. Abhängigkeiten installieren:
    ```bash
    pip install -r requirements.txt
+   playwright install firefox
    ```
+3. Die für Cloudflare-Impersonation nötige Bibliothek `curl_cffi` ist
+   bereits in `requirements.txt` enthalten; zusätzliche Schritte sind
+   nicht erforderlich. Das Tool übergibt `--extractor-args "generic:impersonate"`
+   automatisch.
+
+### Konfiguration
+
+In `config.yaml` lässt sich die Mindestauflösung in Pixel festlegen, ab
+der ein Stream akzeptiert wird. Standardmäßig steht der Wert auf 1080:
+
+```yaml
+min_height: 1080
+```
 
 Beim Download zeigt das Tool gefundene Stream-URLs an und sortiert sie nach Größe.
 Sollte die erste URL von `yt-dlp` nicht unterstützt werden, versucht das Programm
@@ -17,6 +47,9 @@ Wenn ein Kandidat scheitert, wird die Seite mit Playwright erkundet, um darin
 versteckte `.m3u8`/`.mpd`/`.mp4`-Streams zu finden. Gefundene direkte Streams
 werden sofort an den Anfang der Kandidatenliste gestellt und beim nächsten
 Schritt bevorzugt getestet.
+Schlägt ein Download wegen `HTTP 403`/`404` fehl (z. B. durch abgelaufene
+`expires`-Tokens), wird die ursprüngliche Seite automatisch erneut ausgewertet,
+um frische Stream-URLs zu erhalten.
 Falls sämtliche Kandidaten fehlschlagen, endet der Download ohne Ergebnis.
 Alle Meldungen von `yt-dlp` werden zusätzlich in `downloader.log`
 gespeichert, um die Fehlersuche zu erleichtern.

--- a/config.py
+++ b/config.py
@@ -1,21 +1,32 @@
 import os
-from dotenv import load_dotenv
+from pathlib import Path
 import argparse
 
+import yaml
+from dotenv import load_dotenv
 
-def load_config():
+
+def load_config(argv=None):
     load_dotenv()
 
     parser = argparse.ArgumentParser(description="Video Downloader")
     parser.add_argument("--urls", nargs="*", help="Seiten oder direkte Videolinks")
     parser.add_argument("--urls-file", help="Datei mit Links")
     parser.add_argument("--out", default="downloads", help="Ausgabeverzeichnis")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     urls = args.urls or []
     if args.urls_file:
         with open(args.urls_file) as f:
             urls.extend([line.strip() for line in f if line.strip()])
+
+    cfg = {}
+    yaml_path = Path("config.yaml")
+    if yaml_path.exists():
+        with yaml_path.open() as f:
+            cfg = yaml.safe_load(f) or {}
+
+    min_height = int(cfg.get("min_height", 1080))
 
     return type("Config", (), {
         "urls": urls,
@@ -24,4 +35,5 @@ def load_config():
         "koofr_password": os.getenv("KOOFR_PASSWORD"),
         "koofr_base": os.getenv("KOOFR_BASE", ""),
         "surfshark_server": os.getenv("SURFSHARK_SERVER"),
+        "min_height": min_height,
     })()

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,1 @@
+min_height: 1080

--- a/downloader.py
+++ b/downloader.py
@@ -3,12 +3,16 @@ import re
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import requests
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 from playwright.async_api import async_playwright
+
+# flag to avoid repeatedly trying Playwright when the bundled browsers are
+# missing and sniffing is therefore impossible
+PLAYWRIGHT_AVAILABLE = True
 from rich.table import Table
 
 STREAM_EXTS = (".m3u8", ".mpd", ".mp4")
@@ -30,6 +34,18 @@ AD_PATTERNS = [
     "ads.",
 ]
 
+# HTTP headers used for all yt-dlp requests so that hosts protected by
+# Cloudflare see us as a regular browser
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+    "Sec-Fetch-Mode": "navigate",
+}
+
 
 def _fetch_html(url: str) -> str:
     """Retrieve ``url`` using yt-dlp's HTTP client with impersonation.
@@ -39,10 +55,20 @@ def _fetch_html(url: str) -> str:
     mimic a real browser and get the full HTML needed to locate embed
     players.
     """
-    ydl_opts = {"quiet": True, "extractor_args": {"generic": ["impersonate"]}}
-    with YoutubeDL(ydl_opts) as ydl:
-        with ydl.urlopen(url) as resp:
-            data = resp.read()
+    opts = {
+        "quiet": True,
+        "extractor_args": {"generic": ["impersonate"]},
+        "http_headers": HEADERS,
+    }
+    try:
+        with YoutubeDL(opts) as ydl:
+            with ydl.urlopen(url) as resp:
+                data = resp.read()
+    except Exception:
+        opts.pop("extractor_args", None)
+        with YoutubeDL(opts) as ydl:
+            with ydl.urlopen(url) as resp:
+                data = resp.read()
     try:
         return data.decode()
     except Exception:
@@ -57,85 +83,93 @@ def _extract_embeds(html: str) -> list[str]:
 async def _sniff(url: str, ui=None) -> list[str]:
     """Capture media requests by exploring the page with Playwright.
 
-    The function is declared as a coroutine so that ``await`` statements such
-    as ``page.goto`` operate within an async context, preventing the
-    "await outside async function" syntax error reported by some users.
+    If launching the browser fails (e.g. because ``playwright install`` wasn't
+    run), the failure is propagated and ``PLAYWRIGHT_AVAILABLE`` is set to
+    ``False`` so later calls can skip sniffing altogether.
     """
-    async with async_playwright() as pw:
-        browser = await pw.firefox.launch(headless=True)
-        context = await browser.new_context()
+    global PLAYWRIGHT_AVAILABLE
+    try:
+        async with async_playwright() as pw:
+            browser = await pw.firefox.launch(headless=True)
+            context = await browser.new_context()
 
-        async def block_ads(route):
-            if any(pat in route.request.url for pat in AD_PATTERNS):
-                if ui:
-                    ui.log(f"Blocked {route.request.url}")
-                await route.abort()
-            else:
-                await route.continue_()
+            async def block_ads(route):
+                if any(pat in route.request.url for pat in AD_PATTERNS):
+                    if ui:
+                        ui.log(f"Blocked {route.request.url}")
+                    await route.abort()
+                else:
+                    await route.continue_()
 
-        await context.route("**", block_ads)
+            await context.route("**", block_ads)
 
-        page = await context.new_page()
-        page.on("popup", lambda p: asyncio.create_task(p.close()))
-        context.on("page", lambda p: asyncio.create_task(p.close()))
+            page = await context.new_page()
+            page.on("popup", lambda p: asyncio.create_task(p.close()))
+            context.on("page", lambda p: asyncio.create_task(p.close()))
 
-        found: set[str] = set()
+            found: set[str] = set()
 
-        async def handle_response(response):
-            u = response.url.split("?")[0]
-            if u.endswith(STREAM_EXTS):
-                found.add(response.url)
-                if ui:
-                    ui.log(f"Found {response.url}")
+            async def handle_response(response):
+                u = response.url.split("?")[0]
+                if u.endswith(STREAM_EXTS):
+                    found.add(response.url)
+                    if ui:
+                        ui.log(f"Found {response.url}")
 
-        context.on("response", handle_response)
+            context.on("response", handle_response)
 
-        # Visiting some pages takes a while. We do not want navigation
-        # timeouts to abort sniffing, so swallow any errors and keep waiting
-        # for network responses instead.
-        try:
-            await page.goto(url, timeout=60_000)
-        except Exception:
-            pass
-
-        visited: set[int] = set()
-
-        async def trigger(frame):
-            fid = id(frame)
-            if fid in visited:
-                return
-            visited.add(fid)
-
-            selectors = [
-                "button[aria-label*=play i]",
-                "button",
-                "div[role=button]",
-                "div[id*=play]",
-                "div[class*=play]",
-                "span[class*=play]",
-                "video",
-            ]
-            for sel in selectors:
-                try:
-                    await frame.locator(sel).first.click(timeout=1_000, force=True, no_wait_after=True)
-                    break
-                except Exception:
-                    continue
+            # Visiting some pages takes a while. We do not want navigation
+            # timeouts to abort sniffing, so swallow any errors and keep waiting
+            # for network responses instead.
             try:
-                await frame.evaluate("document.querySelectorAll('video').forEach(v=>v.play())")
+                await page.goto(url, timeout=60_000)
             except Exception:
                 pass
 
-        page.on("frameattached", lambda f: asyncio.create_task(trigger(f)))
+            visited: set[int] = set()
 
-        end = asyncio.get_event_loop().time() + 30
-        while asyncio.get_event_loop().time() < end:
-            for f in page.frames:
-                await trigger(f)
-            await asyncio.sleep(2)
+            async def trigger(frame):
+                fid = id(frame)
+                if fid in visited:
+                    return
+                visited.add(fid)
 
-        await browser.close()
-        return list(found)
+                selectors = [
+                    "button[aria-label*=play i]",
+                    "button",
+                    "div[role=button]",
+                    "div[id*=play]",
+                    "div[class*=play]",
+                    "span[class*=play]",
+                    "video",
+                ]
+                for sel in selectors:
+                    try:
+                        await frame.locator(sel).first.click(timeout=1_000, force=True, no_wait_after=True)
+                        break
+                    except Exception:
+                        continue
+                try:
+                    await frame.evaluate("document.querySelectorAll('video').forEach(v=>v.play())")
+                except Exception:
+                    pass
+
+            page.on("frameattached", lambda f: asyncio.create_task(trigger(f)))
+
+            end = asyncio.get_event_loop().time() + 30
+            while asyncio.get_event_loop().time() < end:
+                for f in page.frames:
+                    await trigger(f)
+                await asyncio.sleep(2)
+
+            await browser.close()
+            return list(found)
+    except Exception as e:
+        PLAYWRIGHT_AVAILABLE = False
+        if "Executable doesn't exist" in str(e) and ui:
+            # Offer a concise hint for the common case of missing browsers
+            ui.log("Playwright-Browser fehlen – `playwright install` ausführen")
+        raise
 
 
 def _format_size(size: Optional[int]) -> str:
@@ -148,23 +182,98 @@ def _format_size(size: Optional[int]) -> str:
     return f"{size:.1f} TB"
 
 
-def _head_size(url: str) -> Optional[int]:
+def _probe_with_ffprobe(url: str) -> int:
+    """Return stream height for ``url`` using ffprobe.
+
+    This is slower than yt-dlp metadata probing but more reliable for
+    playlists that do not expose resolution information.
+    """
     try:
-        resp = requests.head(
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=height",
+            "-of",
+            "csv=p=0",
             url,
-            allow_redirects=True,
-            timeout=10,
-            headers={"User-Agent": "Mozilla/5.0"},
-        )
-        cl = resp.headers.get("Content-Length")
-        return int(cl) if cl else None
+        ]
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if out.returncode == 0 and out.stdout.strip():
+            return int(out.stdout.strip())
     except Exception:
-        return None
+        pass
+    return 0
 
 
-def resolve_url(url: str, ui) -> list[str]:
+def _probe_stream(url: str) -> Tuple[int, Optional[int], Optional[str]]:
+    """Return ``(height, size, error)`` for ``url``.
+
+    ``error`` contains a short message if probing failed.
+    """
+    opts = {
+        "quiet": True,
+        "extractor_args": {"generic": ["impersonate"]},
+        "http_headers": HEADERS,
+    }
+    try:
+        with YoutubeDL(opts) as ydl:
+            info = ydl.extract_info(url, download=False)
+    except Exception:
+        try:
+            opts.pop("extractor_args", None)
+            with YoutubeDL(opts) as ydl:
+                info = ydl.extract_info(url, download=False)
+        except Exception as e:
+            height = _probe_with_ffprobe(url)
+            if height:
+                return height, None, None
+            return 0, None, str(e)
+    formats = info.get("formats") or [info]
+    best = max(formats, key=lambda f: f.get("height") or 0)
+    height = best.get("height") or 0
+    size = best.get("filesize") or best.get("filesize_approx")
+    if not height:
+        height = _probe_with_ffprobe(url)
+    return height, size, None
+
+
+def _verify_resolution(path: str) -> int:
+    """Return the height of the first video stream in ``path``.
+
+    This uses ``ffprobe`` on the downloaded file as a fallback verification
+    step since some hosts may not expose accurate metadata via yt-dlp.
+    """
+    try:
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=height",
+            "-of",
+            "csv=p=0",
+            path,
+        ]
+        out = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return int(out.stdout.strip())
+    except Exception:
+        return 0
+
+
+def resolve_url(url: str, ui, min_height: int) -> tuple[list[str], int]:
     if url.split("?")[0].endswith(STREAM_EXTS):
-        return [url]
+        height, _, err = _probe_stream(url)
+        if err:
+            raise RuntimeError(f"Stream nicht nutzbar: {err}")
+        if height < min_height:
+            ui.log(f"Stream bietet nur {height}p")
+        return [url], height
 
     embeds: list[str] = []
     try:
@@ -173,46 +282,80 @@ def resolve_url(url: str, ui) -> list[str]:
     except Exception:
         pass
 
-    sniffed: list[str] = []
-    if not embeds:
-        ui.log("Sniffing stream URL via Playwright")
+    candidates = list(dict.fromkeys(embeds))
+
+    def probe(cands: list[str]):
+        if not cands:
+            return []
+        with ThreadPoolExecutor() as ex:
+            infos = list(ex.map(_probe_stream, cands))
+        items = list(zip(cands, infos))
+        return sorted(
+            items,
+            key=lambda x: ((x[1][0] or 0), x[1][1] or 0),
+            reverse=True,
+        )
+
+    items = probe(candidates)
+
+    for s, (h, _, err) in items:
+        if err:
+            ui.log(f"{s} nicht nutzbar: {err}")
+        elif h < min_height:
+            ui.log(f"{s} bietet nur {h}p")
+
+    hd_items = [(s, info) for s, info in items if info[0] >= min_height and not info[2]]
+
+    if not hd_items and PLAYWRIGHT_AVAILABLE:
+        ui.log(f"Keine Streams mit ≥{min_height}p gefunden – starte Playwright-Sniffing")
+        sniffed: list[str] = []
         try:
             sniffed = asyncio.run(_sniff(url, ui))
         except Exception as e:
             ui.log(f"Sniff failed: {e}")
+        candidates = list(dict.fromkeys(candidates + sniffed))
+        items = probe(candidates)
+        for s, (h, _, err) in items:
+            if err:
+                ui.log(f"{s} nicht nutzbar: {err}")
+            elif h < min_height:
+                ui.log(f"{s} bietet nur {h}p")
+        hd_items = [(s, info) for s, info in items if info[0] >= min_height and not info[2]]
 
-    candidates = list(dict.fromkeys(embeds + sniffed))
-    if not candidates:
-        return [url]
-
-    with ThreadPoolExecutor() as ex:
-        sizes = list(ex.map(_head_size, candidates))
-    items = sorted(zip(candidates, sizes), key=lambda x: x[1] or 0, reverse=True)
+    if not items:
+        raise RuntimeError("Kein Stream in geforderter Qualität gefunden")
 
     table = Table(title="Gefundene Streams")
     table.add_column("Nr")
     table.add_column("URL")
+    table.add_column("Qualität")
     table.add_column("Größe")
-    for i, (s, size) in enumerate(items, start=1):
-        table.add_row(str(i), s, _format_size(size))
+    for i, (s, (h, size, err)) in enumerate(items, start=1):
+        qual = f"{h}p" if h else "?"
+        if err:
+            qual = "-"
+        table.add_row(str(i), s, qual, _format_size(size))
     ui.console.print(table)
 
-    # use Rich's input method so the prompt remains visible while the progress bar is active
+    usable = hd_items if hd_items else [(s, info) for s, info in items if not info[2]]
+    if not usable:
+        raise RuntimeError("Kein Stream in geforderter Qualität gefunden")
+    if not hd_items:
+        ui.log("Kein Stream in geforderter Qualität gefunden – verwende beste verfügbare Qualität")
+
     choice = ui.console.input("Welche URL verwenden? [1]: ")
     try:
         idx = int(choice) - 1 if choice.strip() else 0
     except ValueError:
         idx = 0
-    idx = max(0, min(idx, len(items) - 1))
+    idx = max(0, min(idx, len(usable) - 1))
 
-    # return selected URL first, followed by the remaining candidates so callers
-    # can try alternatives if the first choice fails
-    ordered = [items[idx][0]]
-    ordered.extend(s for i, (s, _) in enumerate(items) if i != idx)
-    return ordered
+    ordered = [usable[idx][0]]
+    ordered.extend(s for i, (s, _) in enumerate(usable) if i != idx)
+    return ordered, usable[idx][1][0] or 0
 
 
-def download(url: str, out: str, ui) -> str:
+def download(url: str, out: str, ui, min_height: int) -> str:
     Path(out).mkdir(parents=True, exist_ok=True)
     result = {"path": None}
 
@@ -248,6 +391,9 @@ def download(url: str, out: str, ui) -> str:
         "concurrent_fragment_downloads": 5,
         # Use HTTP client impersonation to bypass Cloudflare checks on generic sites
         "extractor_args": {"generic": ["impersonate"]},
+        # ensure at least Full HD quality
+        "format": f"bestvideo[height>={min_height}]+bestaudio/best[height>={min_height}]",
+        "http_headers": HEADERS,
         # disable yt-dlp's own progress output so only the rich progress bar is shown
         "noprogress": True,
         "quiet": False,
@@ -286,7 +432,15 @@ def disconnect_vpn(ui) -> None:
 
 
 def process(url: str, cfg, ui) -> None:
-    candidates = resolve_url(url, ui)
+    base_url = url
+    candidates, first_height = resolve_url(base_url, ui, cfg.min_height)
+    min_height = cfg.min_height
+    if first_height < min_height:
+        if first_height:
+            ui.log(f"Falle auf {first_height}p zurück")
+        else:
+            ui.log("Falle auf unbekannte Qualität zurück")
+        min_height = first_height
     seen: set[str] = set()
 
     while candidates:
@@ -295,20 +449,57 @@ def process(url: str, cfg, ui) -> None:
             continue
         seen.add(target)
         ui.log(f"Versuche {target}")
+        height, _, err = _probe_stream(target)
+        if err:
+            ui.log(f"Stream {target} nicht nutzbar: {err}")
+            continue
+        if height < min_height:
+            ui.log(f"Stream {target} bietet nur {height}p – überspringe")
+            continue
         try:
-            path = download(target, cfg.out, ui)
+            path = download(target, cfg.out, ui, min_height)
         except Exception as e:
+            msg = str(e)
             ui.log(f"yt-dlp konnte {target} nicht verarbeiten: {e}; versuche nächste URL")
-            try:
-                extra = asyncio.run(_sniff(target, ui))
-            except Exception as e2:
-                ui.log(f"Sniff fehlgeschlagen: {e2}")
-            else:
-                # Try freshly sniffed stream URLs before any remaining
-                # unresolved candidates so that direct media links are
-                # attempted immediately on the next loop iteration.
-                candidates[0:0] = extra
+            # Tokens in stream URLs often expire and cause 403/404 responses.
+            # When that happens, re-resolve the original page to obtain fresh links.
+            if any(code in msg for code in ("403", "404")):
+                ui.log("Vermutlich abgelaufenes Token – erneuere Links")
+                try:
+                    new_cands, new_first = resolve_url(base_url, ui, cfg.min_height)
+                except Exception as e2:
+                    ui.log(f"Erneute Auflösung fehlgeschlagen: {e2}")
+                else:
+                    if new_first and new_first < min_height:
+                        ui.log(f"Falle auf {new_first}p zurück")
+                        min_height = new_first
+                    fresh = [c for c in new_cands if c not in seen and c not in candidates]
+                    candidates[0:0] = fresh
+            if PLAYWRIGHT_AVAILABLE:
+                try:
+                    extra = asyncio.run(_sniff(target, ui))
+                except Exception as e2:
+                    ui.log(f"Sniff fehlgeschlagen: {e2}")
+                else:
+                    hd_extra = []
+                    for s in extra:
+                        h, _, err = _probe_stream(s)
+                        if err:
+                            ui.log(f"{s} nicht nutzbar: {err}")
+                        elif h < min_height:
+                            ui.log(f"{s} bietet nur {h}p")
+                        else:
+                            hd_extra.append(s)
+                    candidates[0:0] = hd_extra
             continue
         if path:
+            final_height = _verify_resolution(path)
+            if final_height < min_height:
+                ui.log(f"Download bietet nur {final_height}p – versuche nächste URL")
+                try:
+                    Path(path).unlink()
+                except Exception:
+                    pass
+                continue
             upload_to_koofr(path, cfg, ui)
             break

--- a/env.py
+++ b/env.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+VENV_DIR = ROOT / '.venv'
+
+
+def ensure_venv() -> None:
+    """Ensure the script runs inside the local virtual environment.
+
+    If the current interpreter is already the one from `.venv`, nothing
+    happens. Otherwise, if the virtual environment exists and contains a
+    Python executable, the current process is re-executed inside that
+    interpreter. If the virtual environment is missing, execution
+    continues but a warning is printed so features depending on the
+    environment may fail.
+    """
+    if str(Path(sys.prefix).resolve()).startswith(str(VENV_DIR)):
+        return
+
+    python = VENV_DIR / ('Scripts' if os.name == 'nt' else 'bin') / (
+        'python.exe' if os.name == 'nt' else 'python'
+    )
+    if python.exists():
+        print('Re-running inside virtual environment...')
+        os.execv(str(python), [str(python)] + sys.argv)
+    else:
+        print('Warning: virtual environment not found; proceeding with system Python')

--- a/main.py
+++ b/main.py
@@ -1,3 +1,7 @@
+from env import ensure_venv
+
+ensure_venv()
+
 from config import load_config
 from ui import UI
 from downloader import process, connect_vpn, disconnect_vpn

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ yt-dlp
 playwright
 requests
 brotli
+curl_cffi
+PyYAML

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""One-shot environment setup for the video downloader.
+
+This script creates a virtual environment in `.venv`, installs all
+required dependencies (including the libraries needed for Cloudflare
+impersonation), downloads Playwright's Firefox browser and generates a
+small helper script for starting the GUI via double click.
+
+Run with: `python setup.py`
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+VENV_DIR = ROOT / ".venv"
+BIN_DIR = VENV_DIR / ("Scripts" if os.name == "nt" else "bin")
+# Use pythonw.exe on Windows so the GUI launches without a console window.
+PYTHON = BIN_DIR / ("python.exe" if os.name == "nt" else "python")
+PYTHONW = BIN_DIR / ("pythonw.exe" if os.name == "nt" else "python")
+
+
+def run(cmd: list[str]) -> None:
+    """Run a subprocess, printing the command for transparency."""
+    print(" →", " ".join(cmd))
+    subprocess.check_call(cmd)
+
+
+def ensure_venv() -> None:
+    if not VENV_DIR.exists():
+        run([sys.executable, "-m", "venv", str(VENV_DIR)])
+
+
+def install_deps() -> None:
+    run([str(PYTHON), "-m", "pip", "install", "--upgrade", "pip"])
+    run([str(PYTHON), "-m", "pip", "install", "-r", "requirements.txt"])
+    run([str(PYTHON), "-m", "playwright", "install", "firefox"])
+
+
+def create_launcher() -> None:
+    if os.name == "nt":
+        exe = PYTHONW if PYTHONW.exists() else PYTHON
+        launcher = ROOT / "run_gui.bat"
+        content = (
+            "@echo off\r\n"
+            f"cd /d \"{ROOT}\"\r\n"
+            f"start \"\" \"{exe}\" \"{ROOT / 'simple_gui.py'}\" %*\r\n"
+        )
+        launcher.write_text(content, newline="\r\n")
+    else:
+        launcher = ROOT / "run_gui.sh"
+        content = f"#!/bin/sh\ncd \"{ROOT}\"\n\"{PYTHON}\" \"{ROOT / 'simple_gui.py'}\" \"$@\"\n"
+        launcher.write_text(content)
+        launcher.chmod(0o755)
+    print(f"Launcher created: {launcher}")
+
+    desktop = Path(os.environ.get("USERPROFILE" if os.name == "nt" else "HOME", "")) / "Desktop"
+    if desktop.exists():
+        desktop_launcher = desktop / launcher.name
+        if os.name == "nt":
+            desktop_launcher.write_text(content, newline="\r\n")
+        else:
+            desktop_launcher.write_text(content)
+            desktop_launcher.chmod(0o755)
+        print(f"Desktop shortcut created: {desktop_launcher}")
+
+
+def main() -> None:
+    ensure_venv()
+    install_deps()
+    create_launcher()
+    print("\nSetup complete. Use the generated launcher to start the GUI.")
+
+
+if __name__ == "__main__":
+    main()

--- a/simple_gui.py
+++ b/simple_gui.py
@@ -1,10 +1,14 @@
+from env import ensure_venv
+
+ensure_venv()
+
 import tkinter as tk
+from tkinter import ttk
 from tkinter.scrolledtext import ScrolledText
 from threading import Thread
 from queue import Queue
-from pathlib import Path
-import os
-from yt_dlp import YoutubeDL
+from downloader import process
+from config import load_config
 
 
 def append_log(msg: str) -> None:
@@ -12,70 +16,118 @@ def append_log(msg: str) -> None:
     log_queue.put(msg)
 
 
-def download_url(url: str, log) -> None:
-    """Download ``url`` using yt-dlp, logging progress via ``log``."""
-    base = url.rstrip('/').split('/')[-1].split('?')[0]
-    name = os.path.splitext(base)[0]
-    outdir = Path("downloads")
-    outdir.mkdir(exist_ok=True)
-    outtmpl = str(outdir / f"{name}.%(ext)s")
+def queue_progress(name: str, percent: float, speed: str, eta: str) -> None:
+    """Forward progress updates to the main thread."""
+    progress_queue.put((name, percent, speed, eta))
 
-    def hook(d):
-        if d.get("status") == "downloading":
-            total = d.get("total_bytes") or d.get("total_bytes_estimate") or 1
-            percent = d.get("downloaded_bytes", 0) / total * 100
-            speed = d.get("_speed_str", "")
-            eta = d.get("_eta_str", "")
-            log(f"{percent:5.1f}% {speed} ETA {eta}")
-        elif d.get("status") == "finished":
-            log(f"Abgeschlossen: {d.get('filename')}")
 
-    ydl_opts = {
-        "outtmpl": outtmpl,
-        "progress_hooks": [hook],
-        "noprogress": True,
-        "quiet": True,
-    }
-    with YoutubeDL(ydl_opts) as ydl:
-        ydl.download([url])
+class TkConsole:
+    def print(self, *args, **kwargs):
+        append_log(" ".join(str(a) for a in args))
+
+    def input(self, prompt: str = "") -> str:
+        append_log(prompt)
+        return ""  # use default selection
+
+
+class TkUI:
+    def __init__(self):
+        self.console = TkConsole()
+
+    def log(self, msg: str) -> None:
+        append_log(str(msg))
+
+    def update_progress(self, name: str, percent: float, speed: str = "", eta: str = "") -> None:
+        queue_progress(name, percent, speed, eta)
 
 
 def worker(url: str) -> None:
     append_log(f"Starte Download: {url}")
+    ui = TkUI()
+    cfg = load_config([])
     try:
-        download_url(url, append_log)
+        process(url, cfg, ui)
         append_log("Fertig.")
     except Exception as e:
         append_log(f"Fehler: {e}")
+    finally:
+        done_queue.put(True)
 
 
 def start_download() -> None:
     url = entry.get().strip()
     if not url:
         return
+    entry.config(state=tk.DISABLED)
+    btn.config(state=tk.DISABLED)
+    progress_var.set(0)
+    pb.config(mode="indeterminate")
+    pb.start(10)
+    status_var.set("Verbinde…")
     Thread(target=worker, args=(url,), daemon=True).start()
 
 
-def update_log() -> None:
+def poll_queues() -> None:
     while not log_queue.empty():
         text.insert(tk.END, log_queue.get() + "\n")
         text.see(tk.END)
-    root.after(100, update_log)
+
+    while not progress_queue.empty():
+        name, percent, speed, eta = progress_queue.get()
+        if str(pb.cget("mode")) == "indeterminate":
+            pb.stop()
+            pb.config(mode="determinate")
+        progress_var.set(percent)
+        status_var.set(f"{name}: {percent:5.1f}% {speed} ETA {eta}")
+
+    while not done_queue.empty():
+        done_queue.get()
+        pb.stop()
+        pb.config(mode="determinate")
+        progress_var.set(0)
+        status_var.set("Bereit")
+        entry.config(state=tk.NORMAL)
+        btn.config(state=tk.NORMAL)
+
+    root.after(100, poll_queues)
 
 
 root = tk.Tk()
 root.title("Downloader")
 
-entry = tk.Entry(root, width=50)
-entry.pack(padx=5, pady=5)
+style = ttk.Style(root)
+try:
+    style.theme_use("clam")
+except tk.TclError:
+    pass
+style.configure("TProgressbar", thickness=12)
+style.configure("TButton", padding=6)
 
-btn = tk.Button(root, text="Download", command=start_download)
-btn.pack(padx=5, pady=5)
+frame = ttk.Frame(root, padding=10)
+frame.pack(fill="both", expand=True)
+frame.columnconfigure(0, weight=1)
 
-text = ScrolledText(root, width=60, height=20)
-text.pack(padx=5, pady=5)
+entry = ttk.Entry(frame, width=50)
+entry.grid(row=0, column=0, padx=5, pady=5, sticky="ew")
 
-log_queue = Queue()
-update_log()
+btn = ttk.Button(frame, text="Download", command=start_download)
+btn.grid(row=0, column=1, padx=5, pady=5)
+
+progress_var = tk.DoubleVar(value=0)
+pb = ttk.Progressbar(frame, variable=progress_var, maximum=100)
+pb.grid(row=1, column=0, columnspan=2, sticky="ew", padx=5, pady=5)
+
+status_var = tk.StringVar(value="Bereit")
+status = ttk.Label(frame, textvariable=status_var)
+status.grid(row=2, column=0, columnspan=2, sticky="w", padx=5)
+
+text = ScrolledText(frame, width=60, height=15)
+text.grid(row=3, column=0, columnspan=2, sticky="nsew", padx=5, pady=5)
+frame.rowconfigure(3, weight=1)
+
+log_queue: Queue[str] = Queue()
+progress_queue: Queue[tuple[str, float, str, str]] = Queue()
+done_queue: Queue[bool] = Queue()
+poll_queues()
 
 root.mainloop()


### PR DESCRIPTION
## Summary
- create run_gui launcher using pythonw on Windows and copy it to the Desktop for easy double-click starts
- document automated launcher creation in README
- refresh stream URLs when 403/404 errors indicate expired tokens
- ensure run_gui.bat changes to project directory and spawns pythonw in a detached window for reliable double-click launches

## Testing
- `python -m py_compile simple_gui.py downloader.py env.py setup.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b86524449c8321bceba4d506ef3bd5